### PR TITLE
Update sprint_metrics.py

### DIFF
--- a/sprint_metrics.py
+++ b/sprint_metrics.py
@@ -144,9 +144,9 @@ def getSprintMetrics(sprint_report):
             continue
 
         try:
-            issue_points = int(completed["currentEstimateStatistic"]["statFieldValue"]["value"])
+            issue_points_original = int(completed["estimateStatistic"]["statFieldValue"]["value"])
         except:
-            issue_points = 0
+            issue_points_original = 0
 
         points["completed"] += issue_points
         items["completed"] += 1
@@ -154,14 +154,17 @@ def getSprintMetrics(sprint_report):
         unplanned = False
         if completed["key"] in sprint_report["contents"]["issueKeysAddedDuringSprint"].keys():
             unplanned = True
-            points["unplanned_completed"] += issue_points
+            points["unplanned_completed"] += issue_points_original
             items["unplanned_completed"] += 1
         else:
-            points["committed"] += issue_points
-            items["committed"] += 1
-            points["planned_completed"] += issue_points
-            items["planned_completed"] += 1
 
+            points["committed"] += issue_points_original
+            items["committed"] += 1
+            points["planned_completed"] += issue_points_original
+            items["planned_completed"] += 1
+            if issue_points_original != issue_points:
+                points["unplanned_completed"] += issue_points-issue_points_original
+                
         # Story
         if completed["typeName"] == "Story":
             items["stories_completed"] += 1
@@ -278,9 +281,9 @@ def getNotionSection(sprint_data, boardID, sprint_report):
             "Predictability of Commitments "+str('{:6.2f}'.format(points['planned_completed']/points['committed']*100))+"%",
             "Average Velocity (Three Sprints) "+str('{:6.2f}'.format(avgVelocity)),
             "Bugs "+str(items['bugs_completed']),
-            "Completed Issues URL: " + jira_query_url +  urllib.parse.quote(jira_query_jql + completedIssuesIds + ")"),
-            "Not Completed Issues URL: " + jira_query_url+ urllib.parse.quote(jira_query_jql + notCompletedIssuesIds + ")"),
-            "Removed Issues URL: " + jira_query_url+ urllib.parse.quote(jira_query_jql + removedIssuesIds + ")")
+            "Completed Issues URL ("+str(len(sprint_report["contents"]["completedIssues"]))+"): " + jira_query_url + completedIssuesIds + ")",
+            "Not Completed Issues URL ("+str(len(sprint_report["contents"]["issuesNotCompletedInCurrentSprint"]))+"): " + jira_query_url + notCompletedIssuesIds + ")",
+            "Removed Issues URL ("+str(len(sprint_report["contents"]["puntedIssues"]))+"): " + jira_query_url + removedIssuesIds + ")"
     ]
 
 def collectSprintData(projectKey, sprintID=False):

--- a/sprint_metrics.py
+++ b/sprint_metrics.py
@@ -10,7 +10,8 @@ import urllib.parse
 jira_host = 'thetower.atlassian.net'
 jira_url = f"https://{jira_host}/rest/agile/1.0/"
 greenhopper_url = f"https://{jira_host}/rest/greenhopper/1.0/"
-jira_query_url = f"https://{jira_host}/issues/?jql=issueKey in ("
+jira_query_url = f"https://{jira_host}/issues/?jql="
+jira_query_jql = "issueKey in ("
 
 # Auth Data
 netrc = netrc.netrc()
@@ -245,8 +246,10 @@ def getAvgVelocity(board_id, sprintID):
         elif str(velocityEntryKey) == str(sprintID):
             threeSprintVelocityTotal = velocityEntries[velocityEntryKey]['completed']['value']
             sprintCounter = sprintCounter + 1
-
-    return threeSprintVelocityTotal/sprintCounter
+    if sprintCounter > 0:
+        return threeSprintVelocityTotal/sprintCounter
+    else:
+        return 0
 
 
 def getListOfIssueIdsStr(listOfIssues):
@@ -275,9 +278,9 @@ def getNotionSection(sprint_data, boardID, sprint_report):
             "Predictability of Commitments "+str('{:6.2f}'.format(points['planned_completed']/points['committed']*100))+"%",
             "Average Velocity (Three Sprints) "+str('{:6.2f}'.format(avgVelocity)),
             "Bugs "+str(items['bugs_completed']),
-            "Completed Issues URL: " + jira_query_url + completedIssuesIds + ")",
-            "Not Completed Issues URL: " + jira_query_url + notCompletedIssuesIds + ")",
-            "Removed Issues URL: " + jira_query_url + removedIssuesIds + ")"
+            "Completed Issues URL: " + jira_query_url +  urllib.parse.quote(jira_query_jql + completedIssuesIds + ")"),
+            "Not Completed Issues URL: " + jira_query_url+ urllib.parse.quote(jira_query_jql + notCompletedIssuesIds + ")"),
+            "Removed Issues URL: " + jira_query_url+ urllib.parse.quote(jira_query_jql + removedIssuesIds + ")")
     ]
 
 def collectSprintData(projectKey, sprintID=False):

--- a/sprint_metrics.py
+++ b/sprint_metrics.py
@@ -149,9 +149,9 @@ def getSprintMetrics(sprint_report):
             issue_points_original = 0
 
         try:
-            issue_points_original = int(completed["estimateStatistic"]["statFieldValue"]["value"])
+            issue_points = int(completed["currentEstimateStatistic"]["statFieldValue"]["value"])
         except:
-            issue_points_original = 0
+            issue_points = 0
 
         points["completed"] += issue_points
         items["completed"] += 1
@@ -162,12 +162,11 @@ def getSprintMetrics(sprint_report):
             points["unplanned_completed"] += issue_points_original
             items["unplanned_completed"] += 1
         else:
-
             points["committed"] += issue_points_original
             items["committed"] += 1
-            points["planned_completed"] += issue_points_original
+            points["planned_completed"] += issue_points
             items["planned_completed"] += 1
-            if issue_points_original != issue_points:
+            if issue_points_original > issue_points:
                 points["unplanned_completed"] += issue_points-issue_points_original
 
         # Story

--- a/sprint_metrics.py
+++ b/sprint_metrics.py
@@ -166,7 +166,7 @@ def getSprintMetrics(sprint_report):
             items["committed"] += 1
             points["planned_completed"] += issue_points
             items["planned_completed"] += 1
-            if issue_points_original > issue_points:
+            if issue_points_original < issue_points:
                 points["unplanned_completed"] += issue_points-issue_points_original
 
         # Story


### PR DESCRIPTION
Added counters for all three groups of issues (Completed, Not Completed, Removed.
Fixed bug with story size changed during the sprint:
"with BOTS's S22 report (using the slack command — yay!), noticed that if a team adjusts points mid-sprint, the number that it was changed to gets counted in "# of points committed" and "# of planned points completed" — when doing it on my own, in this case I would have put 28 points committed / 30 points completed and 28 planned points completed / 2 unplanned points completed"